### PR TITLE
Generator tool charging mod compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ exported
 devcapture_output.lua
 .vscode/settings.json
 *.png
+.editorconfig

--- a/init/init_generatorcharging.lua
+++ b/init/init_generatorcharging.lua
@@ -26,9 +26,16 @@ env.AddPrefabPostInit("winona_battery_low", function(inst)
     end
 end)
 
-
 env.AddPlayerPostInit(function(inst)
-    local _onbatteryused = inst.components.batteryuser ~= nil and inst.components.batteryuser.onbatteryused or nil
+    local _onbatteryused = nil
+    local batteryuser = inst.components.batteryuser
+
+    if batteryuser ~= nil then
+        inst.UM_isBatteryUser = true
+        _onbatteryused = batteryuser.onbatteryused
+    else
+        batteryuser = inst:AddComponent("batteryuser") -- just the component by itself doesn't do anything
+    end
 
     local function OnChargeFromBattery(inst)
         local items = {}
@@ -64,7 +71,7 @@ env.AddPlayerPostInit(function(inst)
             end
         end
 
-        if selected_item == nil and inst.components.upgrademoduleowner == nil then
+        if selected_item == nil and not inst.UM_isBatteryUser then
             return false
         end
 
@@ -108,8 +115,6 @@ env.AddPlayerPostInit(function(inst)
         end
         return true
     end
-    if inst.components.batteryuser == nil then
-        inst:AddComponent("batteryuser")     -- just the component by itself doesn't do anything
-    end
-    inst.components.batteryuser.onbatteryused = OnChargeFromBattery
+
+    batteryuser.onbatteryused = OnChargeFromBattery
 end)

--- a/postinit/prefabs/lantern.lua
+++ b/postinit/prefabs/lantern.lua
@@ -24,7 +24,7 @@ env.AddPrefabPostInit("lantern", function(inst)
         local OnUnequip_old = inst.components.equippable.onunequipfn
 
         inst.components.equippable.onunequipfn = function(inst, owner)
-            if owner.components.upgrademoduleowner == nil then
+            if not owner.UM_isBatteryUser then
                 local item = owner.components.inventory:GetEquippedItem(EQUIPSLOTS.HEAD)
                 if item ~= nil then
                     if not item:HasTag("electricaltool") and owner:HasTag("batteryuser") then

--- a/postinit/prefabs/minerhat.lua
+++ b/postinit/prefabs/minerhat.lua
@@ -27,7 +27,7 @@ env.AddPrefabPostInit("minerhat", function(inst)
 
         local OnUnequip_old = inst.components.equippable.onunequipfn
         inst.components.equippable.onunequipfn = function(inst, owner)
-            if owner.components.upgrademoduleowner == nil then
+            if not owner.UM_isBatteryUser then
                 local item = owner.components.inventory:GetEquippedItem(EQUIPSLOTS.HANDS)
 
                 if item ~= nil then

--- a/postinit/prefabs/nightstick.lua
+++ b/postinit/prefabs/nightstick.lua
@@ -164,7 +164,7 @@ local function onunequip(inst, owner)
     owner.lightningpriority = nil
     owner:ListenForEvent("lightningstrike", nil)
 
-    if owner.components.upgrademoduleowner == nil then
+    if not owner.UM_isBatteryUser then
         local item = owner.components.inventory:GetEquippedItem(EQUIPSLOTS.HEAD)
         if item ~= nil then
             if not item:HasTag("electricaltool") and owner:HasTag("batteryuser") then

--- a/scripts/prefabs/bugzapper.lua
+++ b/scripts/prefabs/bugzapper.lua
@@ -103,7 +103,7 @@ local function onunequip(inst, owner)
 	end
 	inst.sparktask = nil
 
-	if owner.components.upgrademoduleowner == nil then
+	if not owner.UM_isBatteryUser then
 		local item = owner.components.inventory:GetEquippedItem(EQUIPSLOTS.HEAD)
 		if item ~= nil then
 			if not item:HasTag("electricaltool") and owner:HasTag("batteryuser") then


### PR DESCRIPTION
Rather than checking for WX's `upgrademoduleowner` component in various places, we now check if a character has a `batteryuser` component at the start of `PlayerPostInit` and set a flag to determine whether to run `_onbatteryused` or to remove the "batteryuser" tag upon unequipping a chargeable tool.