### PR TITLE
quick WX post-launch tweaks/fixes

### DIFF
--- a/init/init_character_changes/wx78.lua
+++ b/init/init_character_changes/wx78.lua
@@ -268,7 +268,7 @@ local function OnEatFun(inst, food) -- stuff for charges for food and reversing 
 	elseif food.components.edible:GetHunger(inst) >= 37.5 then charge_hungeramount = 2 
 	elseif food.components.edible:GetHunger(inst) >= 25 then charge_hungeramount = 1 end]] --Gonna try a different system, keep it here if there's a sudden feeling to go back :P
 	
-	local hunger_to_charge = 37.5
+	local hunger_to_charge = 50
 	
 	inst._hungercharge_stored = (inst._hungercharge_stored or 0) + (food.components.edible:GetHunger(inst) / hunger_to_charge)
 	
@@ -308,7 +308,7 @@ local function stats_negate(inst, health_delta, hunger_delta, sanity_delta) --al
 			sanity_delta = sanity_delta * HUNGER_TABLES[inst._hunger_chips]
 		end
 		if hunger_delta < 0 then
-			hunger_delta = hunger_delta * HUNGER_TABLES[inst._hunger_chips ]
+			hunger_delta = hunger_delta * HUNGER_TABLES[inst._hunger_chips]
 		end
 	end
 	
@@ -458,7 +458,7 @@ TUNING.WX78_BEE_TICKPERIOD = 5
 TUNING.WX78_BEE_HEALTHPERTICK = 1
 TUNING.WX78_COLD_ICEMOISTURE = 35
 TUNING.WX78_PERISH_COLDRATE = 0.75
-HUNGER_TABLES={0.25, 0.0, -0.25, -0.5}
+HUNGER_TABLES={0.5, 0.25, 0.00, 0.25}
 TUNING.WX78_CHARGING_FOODS = 
 {
     voltgoatjelly = 8,

--- a/scripts/um_wx78_moduledefs.lua
+++ b/scripts/um_wx78_moduledefs.lua
@@ -67,7 +67,7 @@ local function maxsanity1_activate(inst, wx, isloading)
 
 		wx.components.sanity.dapperness = wx.components.sanity.dapperness + TUNING.DAPPERNESS_TINY
         wx.components.sanity:SetMax(wx.components.sanity.max + TUNING.WX78_MAXSANITY1_BOOST)
-		wx.components.sanity.neg_aura_modifiers:SetModifier(inst, 0.95)
+		wx.components.sanity.neg_aura_modifiers:SetModifier(inst, 0.9)
 
         if not isloading then
             wx.components.sanity:SetPercent(current_sanity_percent, false)
@@ -104,7 +104,7 @@ local function maxsanity_activate(inst, wx, isloading)
 
         wx.components.sanity.dapperness = wx.components.sanity.dapperness + TUNING.WX78_MAXSANITY_DAPPERNESS
         wx.components.sanity:SetMax(wx.components.sanity.max + TUNING.WX78_MAXSANITY_BOOST)
-		wx.components.sanity.neg_aura_modifiers:SetModifier(inst, 0.8)
+		wx.components.sanity.neg_aura_modifiers:SetModifier(inst, 0.75)
 
         if not isloading then
             wx.components.sanity:SetPercent(current_sanity_percent, false)

--- a/scripts/um_wx78_moduledefs.lua
+++ b/scripts/um_wx78_moduledefs.lua
@@ -67,7 +67,7 @@ local function maxsanity1_activate(inst, wx, isloading)
 
 		wx.components.sanity.dapperness = wx.components.sanity.dapperness + TUNING.DAPPERNESS_TINY
         wx.components.sanity:SetMax(wx.components.sanity.max + TUNING.WX78_MAXSANITY1_BOOST)
-		wx.components.sanity.neg_aura_modifiers:SetModifier(inst, 0.9)
+		wx.components.sanity.neg_aura_modifiers:SetModifier(inst, 0.95)
 
         if not isloading then
             wx.components.sanity:SetPercent(current_sanity_percent, false)
@@ -104,7 +104,7 @@ local function maxsanity_activate(inst, wx, isloading)
 
         wx.components.sanity.dapperness = wx.components.sanity.dapperness + TUNING.WX78_MAXSANITY_DAPPERNESS
         wx.components.sanity:SetMax(wx.components.sanity.max + TUNING.WX78_MAXSANITY_BOOST)
-		wx.components.sanity.neg_aura_modifiers:SetModifier(inst, 0.75)
+		wx.components.sanity.neg_aura_modifiers:SetModifier(inst, 0.8)
 
         if not isloading then
             wx.components.sanity:SetPercent(current_sanity_percent, false)
@@ -345,7 +345,7 @@ end
 
 local function onworkingwarmup(wx, data, inst, isattack)
 	local cur = wx.components.temperature.current
-	local tempmult = (cur >= 60 and 0.33) or (cur >= 50 and 0.66) or 1
+	local tempmult = (cur >= 60 and 0.25) or (cur >= 50 and 0.50) or 1
 	
 	if not isattack then
 		wx.components.temperature:SetTemperature(cur + 0.3*tempmult)
@@ -611,7 +611,7 @@ local function taser_onblockedorattacked(wx, data, inst)
 			
 			local tased_duration = wx._taser_chips/1.5
 			
-			if data.attacker.sg ~= nil and not data.attacker.sg.statemem.devoured then
+			if data.attacker.sg ~= nil and not data.attacker.sg.statemem.devoured and not (data.attacker:HasTag("Epic") or data.attacker:HasTag("shadowthrall") or data.attacker:HasTag("shadow")) then
 				data.attacker.sg:GoToState("hit")
 				if data.attacker.tased_stunlocktask == nil then
 				data.attacker.tased_stunlocktask = data.attacker:DoPeriodicTask(0.15, function()


### PR DESCRIPTION
Fixed Electrical circuit softlocking you with one of the Ink Blights;
Made Electrical circuit properly not affect bosses and shadow creatures;
Slightly buffed heat circuit to make it harder to overheat you;
Slightly buffed beanbooster's rate of healing;
Increased amount of hunger required to gain one charge to 50 from 37.5