### PR TITLE
Fixed a WX charge regen bug + small tweaks to both sanity and a small hunger circuits

### DIFF
--- a/postinit/components/sleepingbaguser.lua
+++ b/postinit/components/sleepingbaguser.lua
@@ -40,6 +40,10 @@ AddComponentPostInit("sleepingbaguser", function(SleepingBagUser)
 				self.healthtask:Cancel()
 				self.healthtask = nil
 			end
+			if self._wxsleepchargetask ~= nil then
+				self._wxsleepchargetask:Cancel()
+				self._wxsleepchargetask = nil
+			end
 			_DoWakeUp(self, nostatechange)
 		end
 	end

--- a/scripts/um_wx78_moduledefs.lua
+++ b/scripts/um_wx78_moduledefs.lua
@@ -87,7 +87,7 @@ local function maxsanity1_activate(inst, wx, isloading)
 		wx.components.sanity.dapperness = wx.components.sanity.dapperness + TUNING.DAPPERNESS_TINY
 		wx.components.sanity:SetMax(wx.components.sanity.max + TUNING.WX78_MAXSANITY1_BOOST)
 	end
-        wx.components.sanity.neg_aura_modifiers:SetModifier(inst, 0.9)
+        wx.components.sanity.neg_aura_modifiers:SetModifier(inst, 0.925)
 
         if not isloading then
             wx.components.sanity:SetPercent(current_sanity_percent, false)
@@ -134,7 +134,7 @@ local function maxsanity_activate(inst, wx, isloading)
 		wx.components.sanity.dapperness = wx.components.sanity.dapperness + TUNING.WX78_MAXSANITY_DAPPERNESS
 		wx.components.sanity:SetMax(wx.components.sanity.max + TUNING.WX78_MAXSANITY_BOOST)
 	end
-        wx.components.sanity.neg_aura_modifiers:SetModifier(inst, 0.75)
+        wx.components.sanity.neg_aura_modifiers:SetModifier(inst, 0.8)
 
         if not isloading then
             wx.components.sanity:SetPercent(current_sanity_percent, false)
@@ -925,9 +925,9 @@ local function maxhunger1_activate(inst, wx, isloading)
         end
 
         if wx._cherriftchips and wx._cherriftchips > 0 then
-	    wx.components.hunger.burnratemodifiers:SetModifier(inst, 0.95 * (0.95 ^ wx._cherriftchips))
+	    wx.components.hunger.burnratemodifiers:SetModifier(inst, 0.925 * (0.95 ^ wx._cherriftchips))
 	else
-            wx.components.hunger.burnratemodifiers:SetModifier(inst, 0.95)
+            wx.components.hunger.burnratemodifiers:SetModifier(inst, 0.925)
 	end
     end
 end


### PR DESCRIPTION
- Fixed a bug that caused WX's sleeping charge regen to persist after waking up
- A few small tweaks to secondary effects of following circuits: 
• Small sanity circuit insanity aura reduction: from 10% to 7.5%
• Big sanity circuit insanity aura reduction: from 25% to 20%
• Small hunger circuit hunger slowdown: from 5% to 7.5%