### PR TITLE
Wormwood skill tree tweaks

### DIFF
--- a/modinfo.lua
+++ b/modinfo.lua
@@ -326,7 +326,7 @@ configuration_options = {
     BinaryConfig("wormwood_trapbuffs", "Wormwood - Trap Buffs",
         "Bramble traps do no player damage, reset when you are bloomed near them, and create multiple when crafted.",
         true),
-    BinaryConfig("wormwood_photosynthesis", "Wormwood - Photosynthesis", "Photosynthesis now allows Wormwood to naturally bloom in summer, instead of healing health during the day.", true),
+    BinaryConfig("wormwood_photosynthesis", "Wormwood - SkillTree", "Enables changes to a few of the skills in Wormwood's tree.", true), --kept the name but this should be an overall skilltree config now for potential future changes
     BinaryConfig("wanda_nerf", "Wanda",
         "A bunch of changes to some of Wanda's more overpowered items to make them more balanced.", true),
     SkipSpace(),


### PR DESCRIPTION
- Growth Sprout 1 and 2 have new effect: 5% faster movement speed during full bloom if your health is above 90%/80%
- Flower Power now has a strengthened version of old Growth Sprout in addition to its current effect
(Updated Wormwood's skill tree config description)