### PR TITLE
StatusAnnouncer RegisterStat method nil check

### DIFF
--- a/init/init_statusannouncements.lua
+++ b/init/init_statusannouncements.lua
@@ -2,6 +2,9 @@ local PlayerHud = GLOBAL.require("screens/playerhud")
 local TUNING = GLOBAL.TUNING
 
 local function AddStatAnnouncements(statusAnnouncer, statName, badge, currentMaxFn)
+    -- This shouldn't really ever be nil with status announcements installed.
+    -- Some people crash without this line however: might be something to do with mod priority.
+    if statusAnnouncer.RegisterStat == nil then return end
     statusAnnouncer:RegisterStat(
         statName,
         badge,


### PR DESCRIPTION
This line somehow causes a crash according to bug reports. Added nil check to prevent a crash, though the few who were facing this problem will probably not be able to announce Wathom/Woby's unique stats.