### PR TITLE
Nasty domesticated beefalo bug fix

### DIFF
--- a/postinit/components/rider.lua
+++ b/postinit/components/rider.lua
@@ -7,7 +7,7 @@ env.AddComponentPostInit("rider", function(self)
     function self:Mount(target, instant, ...)
         local ret = _Mount(self, target, instant, ...)
 
-        -- If only Mount() returned true or false if the mount was successful or not.
+        -- If only Mount() returned if the mount was successful or not.
         if target.components.combat == nil
             or not target.components.rideable:TestObedience()
             or not target.components.rideable:TestRider(self.inst)

--- a/postinit/components/rider.lua
+++ b/postinit/components/rider.lua
@@ -7,6 +7,7 @@ env.AddComponentPostInit("rider", function(self)
     function self:Mount(target, instant, ...)
         local ret = _Mount(self, target, instant, ...)
 
+        -- If only Mount() returned true or false if the mount was successful or not.
         if target.components.combat == nil
             or not target.components.rideable:TestObedience()
             or not target.components.rideable:TestRider(self.inst)

--- a/postinit/components/rider.lua
+++ b/postinit/components/rider.lua
@@ -2,29 +2,36 @@ local env = env
 GLOBAL.setfenv(1, GLOBAL)
 -----------------------------------------------------------------
 env.AddComponentPostInit("rider", function(self)
-
     local _Mount = self.Mount
 
     function self:Mount(target, instant, ...)
         local ret = _Mount(self, target, instant, ...)
-        if target.components.combat ~= nil then
-            self.inst.components.combat.redirectdamagefn =
+
+        if target.components.combat == nil
+            or not target.components.rideable:TestObedience()
+            or not target.components.rideable:TestRider(self.inst)
+            or self.riding
+            or target.components.rideable == nil
+            or target.components.rideable:IsBeingRidden() then
+            return ret
+        end
+
+        self.inst.components.combat.redirectdamagefn =
             function(inst, attacker, damage, weapon, stimuli)
                 return target:IsValid()
                     and not (target.components.health ~= nil and target.components.health:IsDead())
                     and not (weapon ~= nil and (
                         weapon.components.projectile ~= nil or
-                            weapon.components.complexprojectile ~= nil or
-                            weapon.components.weapon ~= nil and weapon.components.weapon:CanRangedAttack()
-                        ))
+                        weapon.components.complexprojectile ~= nil or
+                        weapon.components.weapon ~= nil and weapon.components.weapon:CanRangedAttack()
+                    ))
                     and stimuli ~= "electric"
                     and stimuli ~= "darkness"
                     and stimuli ~= "beefalo_half_damage"
                     and target
                     or nil
             end
-        end
+
         return ret
     end
-
 end)

--- a/postinit/components/rider.lua
+++ b/postinit/components/rider.lua
@@ -5,8 +5,6 @@ env.AddComponentPostInit("rider", function(self)
     local _Mount = self.Mount
 
     function self:Mount(target, instant, ...)
-        local ret = _Mount(self, target, instant, ...)
-
         -- If only Mount() returned if the mount was successful or not.
         if target.components.combat == nil
             or not target.components.rideable:TestObedience()
@@ -14,9 +12,12 @@ env.AddComponentPostInit("rider", function(self)
             or self.riding
             or target.components.rideable == nil
             or target.components.rideable:IsBeingRidden() then
-            return ret
+            return _Mount(self, target, instant, ...)
         end
 
+        -- We need to run this before setting redirectdamagefn since vanilla sets it as well in the original function.
+        -- However, we have to do this after the first guard clause since self.riding would be true if we just used a ret from the first line of this function.
+        local ret = _Mount(self, target, instant, ...)
         self.inst.components.combat.redirectdamagefn =
             function(inst, attacker, damage, weapon, stimuli)
                 return target:IsValid()


### PR DESCRIPTION
Fixes a nasty bug where, when a domesticated beefalo refuses another player, Uncompromising Mode would still set the damage redirect function for that player to go to the beefalo; Resulting in damage coming from seemingly nowhere and even the death of the beefalo each time that player is hit from anywhere across the map, continuing until server restart or until said player properly mount/dismounts it which discards the redirect. 

Special thanks to Maximum101 and dogwater for helping catch and test the bug.