### PR TITLE
Consistency patch for Slingshot Ammo.

### DIFF
--- a/scripts/prefabs/slingshotammo_IA.lua
+++ b/scripts/prefabs/slingshotammo_IA.lua
@@ -215,6 +215,12 @@ local function OnHit_Tar(inst, attacker, target)
     inst:Remove()
 end
 
+local function ontaken(inst, target)
+	if target:HasTag("campfire") then
+		target:AddDebuff("halloweenpotion_embers_buff", "halloweenpotion_embers_buff")
+	end
+end
+
 local OBSIDIAN_AURA_EXCLUDE_TAGS = { "noclaustrophobia", "player", "playerghost", "companion", "ghost", "shadow", "shadowminion", "noauradamage", "INLIMBO", "notarget", "noattack", "flight", "flying", "dragonfly", "lavae", "invisible" }
 
 local function DoAreaBurn(inst)
@@ -757,6 +763,7 @@ local function fncommon(symbol, inv, special)
     inst.entity:AddNetwork()
 
     MakeInventoryPhysics(inst)
+    MakeInventoryFloatable(inst, "small", .2, { .85, .9, .85 })
 
     inst.AnimState:SetRayTestOnBB(true)
     inst.AnimState:SetBank("slingshotammo")
@@ -770,7 +777,6 @@ local function fncommon(symbol, inv, special)
 		inst:AddTag("wixieammo_basic")
 	end
 
-    inst:AddTag("molebait")
     inst:AddTag("slingshotammo")
     inst:AddTag("reloaditem_ammo")
 
@@ -788,20 +794,14 @@ local function fncommon(symbol, inv, special)
 
     inst:AddComponent("tradable")
 
-    inst:AddComponent("edible")
-    inst.components.edible.foodtype = FOODTYPE.ELEMENTAL
-    inst.components.edible.hungervalue = 0
-
     inst:AddComponent("stackable")
-    inst.components.stackable.maxsize = TUNING.STACK_SIZE_TINYITEM
+    inst.components.stackable.maxsize = TUNING.STACK_SIZE_PELLET
 
     inst:AddComponent("inspectable")
 
     inst:AddComponent("inventoryitem")
     inst.components.inventoryitem.atlasname = "images/inventoryimages/" .. inv .. ".xml"
-    inst.components.inventoryitem:SetSinks(true)
 
-    inst:AddComponent("bait")
     MakeHauntableLaunch(inst)
 
     return inst
@@ -813,7 +813,12 @@ local function limestone_fn()
     if not TheWorld.ismastersim then
         return inst
     end
-
+    inst:AddTag("molebait")
+    inst:AddComponent("edible")
+    inst.components.edible.foodtype = FOODTYPE.ELEMENTAL
+    inst.components.edible.hungervalue = 0.1
+	
+    inst:AddComponent("bait")
     return inst
 end
 
@@ -823,7 +828,10 @@ local function tar_fn()
     if not TheWorld.ismastersim then
         return inst
     end
-
+    inst:AddComponent("fuel")
+    inst.components.fuel.fuelvalue = TUNING.LARGE_FUEL / 15
+    inst.components.fuel.fueltype = FUELTYPE.SLUDGE
+    inst.components.fuel:SetOnTakenFn(ontaken) --Just like Sludge, it applies a buff that makes campfires last longer. -CB
     return inst
 end
 
@@ -833,7 +841,12 @@ local function obsidian_fn()
     if not TheWorld.ismastersim then
         return inst
     end
-
+    inst:AddTag("molebait")
+    inst:AddComponent("edible")
+    inst.components.edible.foodtype = FOODTYPE.ELEMENTAL
+    inst.components.edible.hungervalue = 1
+	
+    inst:AddComponent("bait")
     return inst
 end
 
@@ -863,7 +876,14 @@ local function flare_fn()
     if not TheWorld.ismastersim then
         return inst
     end
-
+    inst:AddTag("molebait")
+    inst:AddComponent("edible")
+    inst.components.edible.foodtype = FOODTYPE.ELEMENTAL
+    inst.components.edible.hungervalue = 1
+    inst.components.edible.healthvalue = 3
+    inst.components.inventoryitem:SetSinks(true)
+	
+    inst:AddComponent("bait")
     return inst
 end
 

--- a/scripts/prefabs/slingshotammo_extras.lua
+++ b/scripts/prefabs/slingshotammo_extras.lua
@@ -310,7 +310,7 @@ local function fn()
     inst.attacker = nil
 
     inst:AddComponent("stackable")
-    inst.components.stackable.maxsize = TUNING.STACK_SIZE_SMALLITEM
+    inst.components.stackable.maxsize = TUNING.STACK_SIZE_PELLET
 
     inst:AddComponent("inventoryitem")
 
@@ -1483,6 +1483,7 @@ local function fncommon(symbol, inv, overridebuild, special)
     inst.entity:AddNetwork()
 
     MakeInventoryPhysics(inst)
+    MakeInventoryFloatable(inst, "small", .2, { .85, .9, .85 })
 
     inst.AnimState:SetRayTestOnBB(true)
     inst.AnimState:SetBank("slingshotammo")
@@ -1496,7 +1497,6 @@ local function fncommon(symbol, inv, overridebuild, special)
 		inst:AddTag("wixieammo_basic")
 	end
 	
-    inst:AddTag("molebait")
     inst:AddTag("slingshotammo")
     inst:AddTag("reloaditem_ammo")
 
@@ -1514,20 +1514,14 @@ local function fncommon(symbol, inv, overridebuild, special)
 
     inst:AddComponent("tradable")
 
-    inst:AddComponent("edible")
-    inst.components.edible.foodtype = FOODTYPE.ELEMENTAL
-    inst.components.edible.hungervalue = 0
-
     inst:AddComponent("stackable")
-    inst.components.stackable.maxsize = TUNING.STACK_SIZE_TINYITEM
+    inst.components.stackable.maxsize = TUNING.STACK_SIZE_PELLET
 
     inst:AddComponent("inspectable")
 
     inst:AddComponent("inventoryitem")
     inst.components.inventoryitem.atlasname = "images/inventoryimages/" .. inv .. ".xml"
-    inst.components.inventoryitem:SetSinks(true)
 
-    inst:AddComponent("bait")
     MakeHauntableLaunch(inst)
 
     return inst
@@ -1539,7 +1533,14 @@ local function cracker_fn()
     if not TheWorld.ismastersim then
         return inst
     end
+    inst:AddTag("molebait")
+    inst:AddComponent("edible")
+    inst.components.edible.foodtype = FOODTYPE.ELEMENTAL
+    inst.components.edible.hungervalue = 1
+    inst.components.edible.healthvalue = -10
+    inst.components.inventoryitem:SetSinks(true)
 
+    inst:AddComponent("bait")
     return inst
 end
 
@@ -1552,9 +1553,9 @@ local function honey_fn()
 
     inst:AddComponent("edible")
     inst.components.edible.foodtype = FOODTYPE.GOODIES
-    inst.components.edible.hungervalue = 0
-    inst.components.edible.sanityvalue = 1
-    inst.components.edible.healthvalue = 1
+    inst.components.edible.hungervalue = 0.5 --Adjusted to account for skill tree's extra ammo per craft AND UM's stats for Honey * 3. -CB
+    inst.components.edible.sanityvalue = 0.65
+    inst.components.edible.healthvalue = 0.2
 
     return inst
 end
@@ -1575,6 +1576,7 @@ local function tremor_fn()
     if not TheWorld.ismastersim then
         return inst
     end
+    inst.components.inventoryitem:SetSinks(true)
 
     return inst
 end
@@ -1585,7 +1587,12 @@ local function moonrock_fn()
     if not TheWorld.ismastersim then
         return inst
     end
+    inst.components.inventoryitem:SetSinks(true)
 
+    inst:AddComponent("edible")
+    inst.components.edible.foodtype = FOODTYPE.ELEMENTAL
+    inst.components.edible.hungervalue = 1
+    inst.components.edible.sanityvalue = 1
     return inst
 end
 
@@ -1595,6 +1602,7 @@ local function moonglass_fn()
     if not TheWorld.ismastersim then
         return inst
     end
+    inst.components.inventoryitem:SetSinks(true)
 
     return inst
 end
@@ -1605,7 +1613,16 @@ local function salt_fn()
     if not TheWorld.ismastersim then
         return inst
     end
-
+    inst:AddTag("molebait")
+    inst:AddComponent("edible")
+    inst.components.edible.foodtype = FOODTYPE.ELEMENTAL
+    inst.components.edible.hungervalue = 1
+	
+    inst:AddComponent("fuel")
+    inst.components.fuel.fuelvalue = TUNING.MED_FUEL / 7.5 --Fuels Salt Shaker 3000 by the same amount as 1 Salt Crystal. -CB
+    inst.components.fuel.fueltype = FUELTYPE.SALT
+	
+    inst:AddComponent("bait")
     return inst
 end
 
@@ -1615,7 +1632,14 @@ local function goop_fn()
     if not TheWorld.ismastersim then
         return inst
     end
+    inst:AddComponent("edible")
+    inst.components.edible.foodtype = FOODTYPE.GENERIC
+    inst.components.edible.hungervalue = 0.94 --Glommer Goop divided by 10 -CB
+    inst.components.edible.sanityvalue = -5
+    inst.components.edible.healthvalue = 4
 
+    inst:AddComponent("fuel")
+    inst.components.fuel.fuelvalue = TUNING.LARGE_FUEL / 10
     return inst
 end
 
@@ -1635,7 +1659,13 @@ local function lazy_fn()
     if not TheWorld.ismastersim then
         return inst
     end
-
+    inst:AddTag("molebait")
+    inst:AddComponent("edible")
+    inst.components.edible.foodtype = FOODTYPE.ELEMENTAL
+    inst.components.edible.hungervalue = 1
+    inst.components.inventoryitem:SetSinks(true)
+	
+    inst:AddComponent("bait")
     return inst
 end
 
@@ -1645,7 +1675,15 @@ local function shadow_fn()
     if not TheWorld.ismastersim then
         return inst
     end
-
+    inst:AddTag("waterproofer") --Does not get wet, like Nightmare Fuel! -CB
+    inst:AddComponent("waterproofer")
+    inst.components.waterproofer:SetEffectiveness(0)
+    inst:AddComponent("fuel")
+    inst.components.fuel.fueltype = FUELTYPE.NIGHTMARE
+    inst.components.fuel.fuelvalue = TUNING.LARGE_FUEL / 15
+    inst:AddComponent("repairer")
+    inst.components.repairer.repairmaterial = MATERIALS.NIGHTMARE
+    inst.components.repairer.finiteusesrepairvalue = TUNING.NIGHTMAREFUEL_FINITEUSESREPAIRVALUE / 15
     return inst
 end
 


### PR DESCRIPTION
Updated Wixie's Slingshot Ammo to be consistent with Vanilla, like correcting the stack size to 120 and making non-mineral ammo not molebait and float on water. (+other stuff)

I did test each bit of this multiple times, in the past and present.