### PR TITLE
Fix crash while player disconnect to townportal

### DIFF
--- a/init/init_character_changes/wolfgang.lua
+++ b/init/init_character_changes/wolfgang.lua
@@ -303,7 +303,7 @@ AddStategraphActionHandler("wilson", GLOBAL.ActionHandler(GLOBAL.ACTIONS.MIGHTYS
 end))
 
 AddStategraphActionHandler("wilson_client", GLOBAL.ActionHandler(GLOBAL.ACTIONS.MIGHTYSWING, function(inst, action)
-	if not (inst.sg:HasStateTag("attack") and action.target == inst.sg.statemem.attacktarget or IsEntityDead(inst)) then
+	if not (inst.sg:HasStateTag("attack") and action.target == inst.sg.statemem.attacktarget or GLOBAL.IsEntityDead(inst)) then
 		local equip = inst.replica.inventory:GetEquippedItem(EQUIPSLOTS.HANDS)
 		if equip == nil then
 			return "attack"

--- a/postinit/prefabs/townportal.lua
+++ b/postinit/prefabs/townportal.lua
@@ -131,7 +131,7 @@ local function OnStartChanneling(inst, channeler)
 end
 
 local function OnStopChanneling(inst, aborted)
-    TheWorld:PushEvent("townportaldeactivated")
+    TheWorld:PushEvent("townportaldeactivated", inst)
 
     inst.MiniMapEntity:SetIcon("townportal.png")
     inst.MiniMapEntity:SetPriority(0)


### PR DESCRIPTION
Raw crash log:

```
[00:20:45]: [string "scripts/components/townportalregistry.lua"]:60: attempt to index local 'portal' (a nil value)
LUA ERROR stack traceback:
scripts/components/townportalregistry.lua:60 in (local) fn (Lua) <50-62>
   inst = 100036 - world (valid:true)
   portal = nil
scripts/entityscript.lua:1298 in (method) PushEvent_Internal (Lua) <1285-1314>
   self (valid:true) =
      GUID = 100036
      tile_id_conversion_map = table: 0000000015038410
      inlimbo = false
      Transform = Transform (00000000D0B5C7F0)
      shadetiles = table: 00000001000EF430
      Pathfinder = Pathfinder (00000000D0B5BF20)
      GetDisplayName_legion = function - scripts/entityscript.lua:734
      worldstatewatching = table: 00000000EC5CEC10
      spawntask = function - scripts/components/squidspawner.lua:146
      worldprefab = forest
      spawnwaveyjones = function - scripts/components/shadowhandspawner.lua:284
      ismastershard = true
      tile_physics_init = function - scripts/prefabs/forest.lua:584
      watchingcycles = true
      totalcatcoondens = 6
      shard = 100045 - shard_network (valid:true)
      net = 100040 - forest_network (valid:true)
      PostInit = function - scripts/prefabs/world.lua:334
      name = 世界
      OnRemoveEntity = function - scripts/prefabs/world.lua:356
      Map = Map (00000000D0B5C1F0)
      pendingtasks = table: 0000000015D6B3B0
      GetPocketDimensionContainer = function - scripts/prefabs/world.lua:390
      state = table: 00000000E7D41C20
      hideminimap = false
      spawntime = 0
      SetPocketDimensionContainer = function - scripts/prefabs/world.lua:386
      wallupdatecomponents = table: 0000000015037830
      has_ocean = true
      OnLoad = function - ../mods/workshop-2039181790/postinit/any.lua:93
      moonstormwindowovertask = PERIODIC 100036: 0.000000
      cancrossbarriers_flying = true
      PocketDimensionContainers = table: 000000007B648440
      generated = table: 00000000F5D4BC40
      event_listening = table: 00000000E7D40B40
      checkwaveyjonestarget = function - scripts/components/shadowhandspawner.lua:268
      actioncomponents = table: 00000000E7D40140
      data_players = table: 00000000F5D5B870
      lower_components_shadow = table: 00000000E7D40870
      removewaveyjonestarget = function - scripts/components/shadowhandspawner.lua:278
      entity = Entity (00000000E7DBB010)
      reservewaveyjonestarget = function - scripts/components/shadowhandspawner.lua:274
      prefab = world
      updatecomponents = table: 00000000EC5CE8F0
      GroundCreep = GroundCreep (00000000D0B5C6D0)
      OnSave = function - ../mods/workshop-2039181790/postinit/any.lua:82
      shadetile_key_to_leaf_canopy_id = table: 00000001000EEAD0
      persists = false
      meta = table: 0000000063670840
      GetDisplayName = function - ../mods/workshop-1392778117/scripts/datafix_legion.lua:1954
      SoundEmitter = SoundEmitter (00000000D0B5CA30)
      minimap = 100037 - minimap (valid:true)
      CreateTilePhysics = function - scripts/prefabs/world.lua:367
      ismastersim = true
      CanFlyingCrossBarriers = function - scripts/prefabs/world.lua:394
      WaveComponent = WaveComponent (0000000104476880)
      replica = table: 00000000E7D40D70
      topology = table: 00000000F5D5B8C0
      components = table: 00000000E7D40730
      event_listeners = table: 00000000E7D410E0
   event = townportaldeactivated
   data = nil
   immediate = false
   listeners = table: 000000001B9F3990
   tocall = table: 000000010A94EF10
   i = 1
   fn = function - scripts/components/townportalregistry.lua:50
scripts/entityscript.lua:1317 in (method) PushEvent (Lua) <1316-1318>
   self (valid:true) =
      GUID = 100036
      tile_id_conversion_map = table: 0000000015038410
      inlimbo = false
      Transform = Transform (00000000D0B5C7F0)
      shadetiles = table: 00000001000EF430
      Pathfinder = Pathfinder (00000000D0B5BF20)
      GetDisplayName_legion = function - scripts/entityscript.lua:734
      worldstatewatching = table: 00000000EC5CEC10
      spawntask = function - scripts/components/squidspawner.lua:146
[00:20:45]: [string "scripts/components/townportalregistry.lua"]:60: attempt to index local 'portal' (a nil value)
LUA ERROR stack traceback:
    scripts/components/townportalregistry.lua:60 in (local) fn (Lua) <50-62>
    scripts/entityscript.lua:1298 in (method) PushEvent_Internal (Lua) <1285-1314>
    scripts/entityscript.lua:1317 in (method) PushEvent (Lua) <1316-1318>
    ../mods/workshop-2039181790/postinit/prefabs/townportal.lua:134 in (field) onstopchannelingfn (Lua) <133-151>
    scripts/components/channelable.lua:201 in (method) StopChanneling (Lua) <149-210>
    scripts/stategraphs/SGwilson.lua:18724 in (field) onexit (Lua) <18717-18726>
    scripts/stategraph.lua:539 in (method) GoToState (Lua) <529-600>
    scripts/stategraphs/SGwilson.lua:1439 in () ? (Lua) <1406-1447>
    =(tail call):-1 in ()  (tail) <-1--1>
    scripts/stategraph.lua:468 in (method) HandleEvent (Lua) <463-471>
    scripts/stategraph.lua:479 in (method) HandleEvents (Lua) <473-488>
    scripts/stategraph.lua:154 in (method) UpdateEvents (Lua) <148-157>
    scripts/stategraph.lua:145 in (method) Update (Lua) <109-146>
    scripts/update.lua:288 in () ? (Lua) <224-298>
```